### PR TITLE
feat: Add "Skip for Now" option on first launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "GitTop"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "chrono",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "GitTop"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 description = "Why spin up a browser just to check your GitHub notifications?"
 authors = ["AmarBego"]

--- a/bucket/gittop.json
+++ b/bucket/gittop.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A lightweight GitHub notifications client. Why spin up a browser just to check your GitHub notifications?",
   "homepage": "https://github.com/AmarBego/GitTop",
   "license": {
@@ -9,8 +9,8 @@
   "notes": "User settings are stored in '$env:APPDATA\\GitTop'. Remove this folder manually for a clean uninstall.",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/AmarBego/GitTop/releases/download/v0.1.8/gittop-windows-x86_64.zip",
-      "hash": "2a71bc942a48941848ddcfe0d28bb2e9c03e96bc8ba96ee09844bb947a62bd32"
+      "url": "https://github.com/AmarBego/GitTop/releases/download/v0.1.9/gittop-windows-x86_64.zip",
+      "hash": "1c8e1e953ecb3e16f4706ba6137aa7f538b15d4a8e83d343c46e4e776ced6088"
     }
   },
   "extract_dir": "gittop-windows-x86_64",

--- a/packaging/innosetup/gittop.iss
+++ b/packaging/innosetup/gittop.iss
@@ -8,7 +8,7 @@
 #define MyAppDataFolder "GitTop"
 
 [Setup]
-AppId={{9C1A2F74-5A9F-4F71-8C7B-9CDAE2F5E0B6}
+AppId={{9C1A2F74-5A9F-4F71-8C7B-9CDAE2F5E0B6}}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
 AppPublisher={#MyAppPublisher}


### PR DESCRIPTION
The main purpose is to create simulated "guest" user data and an empty interface to skip the token import on the first launch.

However, to be honest, this effect is not much, and it may also cause other potential problems. Just provide ideas!