### PR TITLE
feat: musl support + autostart on non systemd

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -75,7 +75,7 @@ jobs:
           VERSION="${VERSION#v}"
 
           # Download tarball and calculate checksum
-          URL="https://github.com/AmarBego/GitTop/releases/download/v${VERSION}/gittop-${VERSION}-linux-x86_64.tar.gz"
+          URL="https://github.com/AmarBego/GitTop/releases/download/v${VERSION}/gittop-${VERSION}-linux-gnu-x86_64.tar.gz"
           curl -L -o /tmp/gittop.tar.gz "$URL"
           CHECKSUM=$(sha256sum /tmp/gittop.tar.gz | cut -d' ' -f1)
           rm /tmp/gittop.tar.gz

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -124,7 +124,7 @@ jobs:
           sed -i "s/%{_version}/${VERSION}/g" packaging/copr/gittop.spec
 
           # Download source tarball
-          SOURCE_URL="https://github.com/AmarBego/GitTop/releases/download/v${VERSION}/gittop-${VERSION}-linux-x86_64.tar.gz"
+          SOURCE_URL="https://github.com/AmarBego/GitTop/releases/download/v${VERSION}/gittop-${VERSION}-linux-gnu-x86_64.tar.gz"
           echo "Downloading source from: $SOURCE_URL"
           wget -q "$SOURCE_URL"
 

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Build Flatpak
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
-          bundle: gittop-${{ needs.check.outputs.version }}-linux-x86_64.flatpak
+          bundle: gittop-${{ needs.check.outputs.version }}-linux-gnu-x86_64.flatpak
           manifest-path: packaging/flatpak/io.github.AmarBego.GitTop.ci.yml
           cache-key: flatpak-builder-${{ github.sha }}
           upload-artifact: false
@@ -122,7 +122,7 @@ jobs:
           VERSION="${{ needs.check.outputs.version }}"
 
           gh release upload ${{ needs.check.outputs.tag }} \
-            gittop-${VERSION}-linux-x86_64.flatpak \
+            gittop-${VERSION}-linux-gnu-x86_64.flatpak \
             --clobber \
             --repo AmarBego/GitTop
 
@@ -130,6 +130,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: flatpak-bundle
-          path: gittop-${{ needs.check.outputs.version }}-linux-x86_64.flatpak
+          path: gittop-${{ needs.check.outputs.version }}-linux-gnu-x86_64.flatpak
 
       - uses: kesin11/actions-timeline@v2

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -107,12 +107,22 @@ jobs:
           echo "Generated sources with $(grep -c '"url"' packaging/flatpak/generated-sources.json) crates"
           echo "::endgroup::"
 
-      - name: Build Flatpak
+      - name: Build Flatpak (x86_64)
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: gittop-${{ needs.check.outputs.version }}-linux-gnu-x86_64.flatpak
           manifest-path: packaging/flatpak/io.github.AmarBego.GitTop.ci.yml
           cache-key: flatpak-builder-${{ github.sha }}
+          arch: x86_64
+          upload-artifact: false
+
+      - name: Build Flatpak (aarch64)
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: gittop-${{ needs.check.outputs.version }}-linux-gnu-aarch64.flatpak
+          manifest-path: packaging/flatpak/io.github.AmarBego.GitTop.ci.yml
+          cache-key: flatpak-builder-aarch64-${{ github.sha }}
+          arch: aarch64
           upload-artifact: false
 
       - name: Upload Flatpak to Release
@@ -123,6 +133,7 @@ jobs:
 
           gh release upload ${{ needs.check.outputs.tag }} \
             gittop-${VERSION}-linux-gnu-x86_64.flatpak \
+            gittop-${VERSION}-linux-gnu-aarch64.flatpak \
             --clobber \
             --repo AmarBego/GitTop
 
@@ -130,6 +141,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: flatpak-bundle
-          path: gittop-${{ needs.check.outputs.version }}-linux-gnu-x86_64.flatpak
+          path: |
+            gittop-${{ needs.check.outputs.version }}-linux-gnu-x86_64.flatpak
+            gittop-${{ needs.check.outputs.version }}-linux-gnu-aarch64.flatpak
 
       - uses: kesin11/actions-timeline@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,17 @@ jobs:
             target/installer/*.exe
 
   build-linux:
-    name: Build Linux
+    name: Build Linux (${{ matrix.target }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            libc: gnu
+          - target: x86_64-unknown-linux-musl
+            libc: musl
     permissions:
       contents: read
     steps:
@@ -122,7 +131,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ env.TARGET_LINUX }}
+          targets: ${{ matrix.target }}
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -131,6 +140,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libglib2.0-dev libgtk-3-dev
+          if [ "${{ matrix.libc }}" = "musl" ]; then
+            sudo apt-get install -y musl-tools
+          fi
 
       - name: Install packaging tools
         uses: taiki-e/install-action@v2
@@ -140,22 +152,21 @@ jobs:
       - name: Build release
         env:
           SCCACHE_GHA_ENABLED: "true"
-          SCCACHE_GHA_CACHE_PREFIX: "sccache-linux"
+          SCCACHE_GHA_CACHE_PREFIX: "sccache-linux-${{ matrix.libc }}"
           RUSTC_WRAPPER: "sccache"
-        run: cargo build --release --target ${{ env.TARGET_LINUX }}
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Generate packages
         run: |
           # Inject the dynamic version from the tag into Cargo.toml so packaging tools use it
-          # This handles prereleases (e.g., 0.3.0-alpha.7) correctly
           sed -i 's/^version = ".*"/version = "${{ steps.version.outputs.version }}"/' Cargo.toml
 
           # Ensure binary is in the expected location for packaging tools
           mkdir -p target/release
-          cp target/${{ env.TARGET_LINUX }}/release/${{ env.APP_NAME }} target/release/
+          cp target/${{ matrix.target }}/release/${{ env.APP_NAME }} target/release/
 
           # Generate .deb
-          cargo deb --no-build --target ${{ env.TARGET_LINUX }}
+          cargo deb --no-build --target ${{ matrix.target }}
 
           # Generate .rpm
           cargo generate-rpm
@@ -163,48 +174,46 @@ jobs:
           # Move packages to a staging area
           mkdir -p dist
 
-          # Name format: gittop-{version}-linux-x86_64.{deb,rpm}
-
           # Handle .deb
-          for file in target/${{ env.TARGET_LINUX }}/debian/*.deb target/debian/*.deb; do
+          for file in target/${{ matrix.target }}/debian/*.deb target/debian/*.deb; do
             [ -e "$file" ] || continue
-            # Standardize name
-            mv "$file" "dist/gittop-${{ steps.version.outputs.version }}-linux-x86_64.deb"
+            mv "$file" "dist/gittop-${{ steps.version.outputs.version }}-linux-${{ matrix.libc }}-x86_64.deb"
             break
           done
 
           # Handle .rpm
           for file in target/generate-rpm/*.rpm; do
             [ -e "$file" ] || continue
-             mv "$file" "dist/gittop-${{ steps.version.outputs.version }}-linux-x86_64.rpm"
+             mv "$file" "dist/gittop-${{ steps.version.outputs.version }}-linux-${{ matrix.libc }}-x86_64.rpm"
              break
           done
 
       - name: Package Linux release
         run: |
           echo "::group::Prepare Staging Directory"
-          mkdir -p gittop-${{ steps.version.outputs.version }}-linux-x86_64
-          cp target/${{ env.TARGET_LINUX }}/release/${{ env.APP_NAME }} gittop-${{ steps.version.outputs.version }}-linux-x86_64/
-          cp LICENSE.md gittop-${{ steps.version.outputs.version }}-linux-x86_64/
-          cp README.txt gittop-${{ steps.version.outputs.version }}-linux-x86_64/
-          cp src/platform/resources/gittop.desktop gittop-${{ steps.version.outputs.version }}-linux-x86_64/
-          cp assets/images/GitTop-256x256.png gittop-${{ steps.version.outputs.version }}-linux-x86_64/gittop.png
-          chmod +x gittop-${{ steps.version.outputs.version }}-linux-x86_64/${{ env.APP_NAME }}
+          staging_dir="gittop-${{ steps.version.outputs.version }}-linux-${{ matrix.libc }}-x86_64"
+          mkdir -p "$staging_dir"
+          cp target/${{ matrix.target }}/release/${{ env.APP_NAME }} "$staging_dir/"
+          cp LICENSE.md "$staging_dir/"
+          cp README.txt "$staging_dir/"
+          cp src/platform/resources/gittop.desktop "$staging_dir/"
+          cp assets/images/GitTop-256x256.png "$staging_dir/gittop.png"
+          chmod +x "$staging_dir/${{ env.APP_NAME }}"
           echo "::endgroup::"
 
           echo "::group::Create Tarball"
           tar --sort=name \
               --owner=0 --group=0 --numeric-owner \
-              -czf gittop-${{ steps.version.outputs.version }}-linux-x86_64.tar.gz \
-              gittop-${{ steps.version.outputs.version }}-linux-x86_64
+              -czf "$staging_dir.tar.gz" \
+              "$staging_dir"
           echo "::endgroup::"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: linux-x86_64
+          name: linux-${{ matrix.libc }}-x86_64
           path: |
-            gittop-*-linux-x86_64.tar.gz
+            gittop-*-linux-${{ matrix.libc }}-x86_64.tar.gz
             dist/*.deb
             dist/*.rpm
 
@@ -234,9 +243,12 @@ jobs:
           sha256sum \
             artifacts/windows-x86_64/gittop-*-windows-x86_64.zip \
             artifacts/windows-x86_64/target/installer/*.exe \
-            artifacts/linux-x86_64/gittop-*-linux-x86_64.tar.gz \
-            artifacts/linux-x86_64/dist/*.deb \
-            artifacts/linux-x86_64/dist/*.rpm \
+            artifacts/linux-gnu-x86_64/gittop-*-linux-gnu-x86_64.tar.gz \
+            artifacts/linux-gnu-x86_64/dist/*.deb \
+            artifacts/linux-gnu-x86_64/dist/*.rpm \
+            artifacts/linux-musl-x86_64/gittop-*-linux-musl-x86_64.tar.gz \
+            artifacts/linux-musl-x86_64/dist/*.deb \
+            artifacts/linux-musl-x86_64/dist/*.rpm \
             | sort > SHA256SUMS.txt
 
       - name: Create GitHub Release
@@ -249,9 +261,12 @@ jobs:
           files: |
             artifacts/windows-x86_64/gittop-*-windows-x86_64.zip
             artifacts/windows-x86_64/target/installer/*.exe
-            artifacts/linux-x86_64/gittop-*-linux-x86_64.tar.gz
-            artifacts/linux-x86_64/dist/*.deb
-            artifacts/linux-x86_64/dist/*.rpm
+            artifacts/linux-gnu-x86_64/gittop-*-linux-gnu-x86_64.tar.gz
+            artifacts/linux-gnu-x86_64/dist/*.deb
+            artifacts/linux-gnu-x86_64/dist/*.rpm
+            artifacts/linux-musl-x86_64/gittop-*-linux-musl-x86_64.tar.gz
+            artifacts/linux-musl-x86_64/dist/*.deb
+            artifacts/linux-musl-x86_64/dist/*.rpm
             SHA256SUMS.txt
 
       # Save release info for downstream workflows (e.g., AUR)
@@ -288,6 +303,7 @@ jobs:
         with:
           name: |
             windows-x86_64
-            linux-x86_64
+            linux-gnu-x86_64
+            linux-musl-x86_64
 
       - uses: kesin11/actions-timeline@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,17 @@ env:
 
 jobs:
   build-windows:
-    name: Build Windows
+    name: Build Windows (${{ matrix.target }})
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64-pc-windows-msvc, aarch64-pc-windows-msvc]
+        include:
+          - target: x86_64-pc-windows-msvc
+            arch: x86_64
+          - target: aarch64-pc-windows-msvc
+            arch: aarch64
     permissions:
       contents: read
     outputs:
@@ -49,7 +58,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ env.TARGET_WINDOWS }}
+          targets: ${{ matrix.target }}
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -57,42 +66,42 @@ jobs:
       - name: Build release
         env:
           SCCACHE_GHA_ENABLED: "true"
-          SCCACHE_GHA_CACHE_PREFIX: "sccache-windows"
+          SCCACHE_GHA_CACHE_PREFIX: "sccache-windows-${{ matrix.arch }}"
           RUSTC_WRAPPER: "sccache"
-        run: cargo build --release --target ${{ env.TARGET_WINDOWS }}
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Build EXE installer (Inno Setup)
         shell: pwsh
         run: |
           $version = "${{ steps.version.outputs.version }}"
-          # Inno Setup is pre-installed on windows-latest at this path
-          & "C:\Program Files (x86)\Inno Setup 6\iscc.exe" /DMyAppVersion="$version" packaging/innosetup/gittop.iss
+          # We need to tell InnoSetup which arch we are building for
+          $archParams = if ("${{ matrix.arch }}" -eq "aarch64") { "/DArchitecturesAllowed=arm64 /DArchitecturesInstallIn64BitMode=arm64" } else { "" }
+          & "C:\Program Files (x86)\Inno Setup 6\iscc.exe" /DMyAppVersion="$version" /DAppArch="${{ matrix.arch }}" $archParams packaging/innosetup/gittop.iss
 
       - name: Packaging Windows release
         shell: pwsh
         run: |
           echo "::group::Prepare Staging Directory"
-          $stagingDir = "gittop-${{ steps.version.outputs.version }}-windows-x86_64"
+          $stagingDir = "gittop-${{ steps.version.outputs.version }}-windows-${{ matrix.arch }}"
           New-Item -ItemType Directory -Force -Path $stagingDir
           echo "::endgroup::"
 
           echo "::group::Copy Artifacts"
-          Copy-Item "target/${{ env.TARGET_WINDOWS }}/release/${{ env.APP_NAME }}.exe" "$stagingDir/"
+          Copy-Item "target/${{ matrix.target }}/release/${{ env.APP_NAME }}.exe" "$stagingDir/"
           Copy-Item "LICENSE.md" "$stagingDir/"
           Copy-Item "README.txt" "$stagingDir/"
           echo "::endgroup::"
 
           echo "::group::Compress Archive"
-          # Zip the directory (not glob) for deterministic contents
-          Compress-Archive -Path $stagingDir -DestinationPath "gittop-${{ steps.version.outputs.version }}-windows-x86_64.zip"
+          Compress-Archive -Path $stagingDir -DestinationPath "gittop-${{ steps.version.outputs.version }}-windows-${{ matrix.arch }}.zip"
           echo "::endgroup::"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: windows-x86_64
+          name: windows-${{ matrix.arch }}
           path: |
-            gittop-*-windows-x86_64.zip
+            gittop-*-windows-${{ matrix.arch }}.zip
             target/installer/*.exe
 
   build-linux:
@@ -101,12 +110,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl]
+        target: 
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
         include:
           - target: x86_64-unknown-linux-gnu
             libc: gnu
+            arch: x86_64
+            use_cross: false
           - target: x86_64-unknown-linux-musl
             libc: musl
+            arch: x86_64
+            use_cross: false
+          - target: aarch64-unknown-linux-gnu
+            libc: gnu
+            arch: aarch64
+            use_cross: true
+          - target: aarch64-unknown-linux-musl
+            libc: musl
+            arch: aarch64
+            use_cross: true
     permissions:
       contents: read
     steps:
@@ -136,7 +161,8 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Install system dependencies
+      - name: Install system dependencies (Native)
+        if: matrix.use_cross == false
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libglib2.0-dev libgtk-3-dev
@@ -144,17 +170,32 @@ jobs:
             sudo apt-get install -y musl-tools
           fi
 
+      - name: Install cross
+        if: matrix.use_cross == true
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
       - name: Install packaging tools
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-deb,cargo-generate-rpm
 
-      - name: Build release
+      - name: Build release (Native)
+        if: matrix.use_cross == false
         env:
           SCCACHE_GHA_ENABLED: "true"
-          SCCACHE_GHA_CACHE_PREFIX: "sccache-linux-${{ matrix.libc }}"
+          SCCACHE_GHA_CACHE_PREFIX: "sccache-linux-${{ matrix.libc }}-${{ matrix.arch }}"
           RUSTC_WRAPPER: "sccache"
         run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build release (Cross)
+        if: matrix.use_cross == true
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          SCCACHE_GHA_CACHE_PREFIX: "sccache-linux-${{ matrix.libc }}-${{ matrix.arch }}"
+          RUSTC_WRAPPER: "sccache"
+        run: cross build --release --target ${{ matrix.target }}
 
       - name: Generate packages
         run: |
@@ -166,7 +207,11 @@ jobs:
           cp target/${{ matrix.target }}/release/${{ env.APP_NAME }} target/release/
 
           # Generate .deb
-          cargo deb --no-build --target ${{ matrix.target }}
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            cargo deb --no-build --target ${{ matrix.target }}
+          else
+            cargo deb --no-build --target ${{ matrix.target }}
+          fi
 
           # Generate .rpm
           cargo generate-rpm
@@ -177,21 +222,21 @@ jobs:
           # Handle .deb
           for file in target/${{ matrix.target }}/debian/*.deb target/debian/*.deb; do
             [ -e "$file" ] || continue
-            mv "$file" "dist/gittop-${{ steps.version.outputs.version }}-linux-${{ matrix.libc }}-x86_64.deb"
+            mv "$file" "dist/gittop-${{ steps.version.outputs.version }}-linux-${{ matrix.libc }}-${{ matrix.arch }}.deb"
             break
           done
 
           # Handle .rpm
           for file in target/generate-rpm/*.rpm; do
             [ -e "$file" ] || continue
-             mv "$file" "dist/gittop-${{ steps.version.outputs.version }}-linux-${{ matrix.libc }}-x86_64.rpm"
+             mv "$file" "dist/gittop-${{ steps.version.outputs.version }}-linux-${{ matrix.libc }}-${{ matrix.arch }}.rpm"
              break
           done
 
       - name: Package Linux release
         run: |
           echo "::group::Prepare Staging Directory"
-          staging_dir="gittop-${{ steps.version.outputs.version }}-linux-${{ matrix.libc }}-x86_64"
+          staging_dir="gittop-${{ steps.version.outputs.version }}-linux-${{ matrix.libc }}-${{ matrix.arch }}"
           mkdir -p "$staging_dir"
           cp target/${{ matrix.target }}/release/${{ env.APP_NAME }} "$staging_dir/"
           cp LICENSE.md "$staging_dir/"
@@ -211,9 +256,9 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: linux-${{ matrix.libc }}-x86_64
+          name: linux-${{ matrix.libc }}-${{ matrix.arch }}
           path: |
-            gittop-*-linux-${{ matrix.libc }}-x86_64.tar.gz
+            gittop-*-linux-${{ matrix.libc }}-${{ matrix.arch }}.tar.gz
             dist/*.deb
             dist/*.rpm
 
@@ -243,12 +288,20 @@ jobs:
           sha256sum \
             artifacts/windows-x86_64/gittop-*-windows-x86_64.zip \
             artifacts/windows-x86_64/target/installer/*.exe \
+            artifacts/windows-aarch64/gittop-*-windows-aarch64.zip \
+            artifacts/windows-aarch64/target/installer/*.exe \
             artifacts/linux-gnu-x86_64/gittop-*-linux-gnu-x86_64.tar.gz \
             artifacts/linux-gnu-x86_64/dist/*.deb \
             artifacts/linux-gnu-x86_64/dist/*.rpm \
             artifacts/linux-musl-x86_64/gittop-*-linux-musl-x86_64.tar.gz \
             artifacts/linux-musl-x86_64/dist/*.deb \
             artifacts/linux-musl-x86_64/dist/*.rpm \
+            artifacts/linux-gnu-aarch64/gittop-*-linux-gnu-aarch64.tar.gz \
+            artifacts/linux-gnu-aarch64/dist/*.deb \
+            artifacts/linux-gnu-aarch64/dist/*.rpm \
+            artifacts/linux-musl-aarch64/gittop-*-linux-musl-aarch64.tar.gz \
+            artifacts/linux-musl-aarch64/dist/*.deb \
+            artifacts/linux-musl-aarch64/dist/*.rpm \
             | sort > SHA256SUMS.txt
 
       - name: Create GitHub Release
@@ -259,14 +312,11 @@ jobs:
           prerelease: ${{ needs.build-windows.outputs.is_prerelease == 'true' }}
           generate_release_notes: true
           files: |
-            artifacts/windows-x86_64/gittop-*-windows-x86_64.zip
-            artifacts/windows-x86_64/target/installer/*.exe
-            artifacts/linux-gnu-x86_64/gittop-*-linux-gnu-x86_64.tar.gz
-            artifacts/linux-gnu-x86_64/dist/*.deb
-            artifacts/linux-gnu-x86_64/dist/*.rpm
-            artifacts/linux-musl-x86_64/gittop-*-linux-musl-x86_64.tar.gz
-            artifacts/linux-musl-x86_64/dist/*.deb
-            artifacts/linux-musl-x86_64/dist/*.rpm
+            artifacts/windows-*/gittop-*-windows-*.zip
+            artifacts/windows-*/target/installer/*.exe
+            artifacts/linux-*/gittop-*-linux-*.tar.gz
+            artifacts/linux-*/dist/*.deb
+            artifacts/linux-*/dist/*.rpm
             SHA256SUMS.txt
 
       # Save release info for downstream workflows (e.g., AUR)
@@ -303,7 +353,10 @@ jobs:
         with:
           name: |
             windows-x86_64
+            windows-aarch64
             linux-gnu-x86_64
             linux-musl-x86_64
+            linux-gnu-aarch64
+            linux-musl-aarch64
 
       - uses: kesin11/actions-timeline@v2

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ packaging/chocolatey/*.nupkg
 Thumbs.db
 
 # Binaries
-gittop-linux-x86_64
+gittop-linux-gnu-x86_64
+gittop-linux-musl-x86_64

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ Thumbs.db
 # Binaries
 gittop-linux-gnu-x86_64
 gittop-linux-musl-x86_64
+gittop-linux-gnu-aarch64
+gittop-linux-musl-aarch64

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   </a>
   <br/>
   <a href="#linux">
-    <img src="https://img.shields.io/badge/Flatpak-Supported-4A90D9?style=flat-square&logo=flathub&logoColor=white" alt="Flatpak">
+    <img src="https://img.shields.io/badge/Flatpak-Pending-4A90D9?style=flat-square&logo=flathub&logoColor=white" alt="Flatpak">
   </a>
   <a href="#linux">
     <img src="https://img.shields.io/badge/AUR-Supported-1793D1?style=flat-square&logo=arch-linux&logoColor=white" alt="AUR">
@@ -27,7 +27,7 @@
     <img src="https://img.shields.io/badge/COPR-Supported-294172?style=flat-square&logo=fedora&logoColor=white" alt="COPR">
   </a>
   <a href="#linux">
-    <img src="https://img.shields.io/badge/Snap-Supported-82BEA0?style=flat-square&logo=snapcraft&logoColor=white" alt="Snap">
+    <img src="https://img.shields.io/badge/Snap-Pending-red?style=flat-square&logo=snapcraft&logoColor=white" alt="Snap">
   </a>
 </p>
 
@@ -94,12 +94,10 @@ scoop install gittop
 ### Linux
 
 **Flatpak:**
+Download the `.flatpak` bundle from the [latest release](https://github.com/AmarBego/GitTop/releases/latest).
 ```bash
-# From Flathub (when published)
-# flatpak install flathub io.github.AmarBego.GitTop
-
-# Or install from bundled .flatpak file
-flatpak install gittop-VERSION.flatpak
+# Install from bundled .flatpak file
+flatpak install gittop-v0.4.0-linux-gnu-x86_64.flatpak
 flatpak run io.github.AmarBego.GitTop
 ```
 
@@ -118,16 +116,18 @@ sudo dnf copr enable amarbego/gittop
 sudo dnf install gittop
 ```
 
-**Ubuntu/Debian (Snap):**
+~~**Ubuntu/Debian (Snap):**~~
 ```bash
-sudo snap install gittop
+# NOT MERGED sudo snap install gittop~~
 ```
 
-**Manual:** Download `gittop-linux-x86_64.tar.gz` from releases:
+**Manual:** Download `gittop-linux-gnu-x86_64.tar.gz` (or `-musl-` for Void Linux/Alpine) from releases:
+
 ```bash
-tar xzf gittop-linux-x86_64.tar.gz
-./gittop-linux-x86_64/gittop
+tar xzf gittop-v0.4.0-linux-gnu-x86_64.tar.gz
+./gittop-v0.4.0-linux-gnu-x86_64/gittop
 ```
+
 
 ## Building from Source
 

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -1,5 +1,6 @@
-gittop-linux-x86_64.tar.gz
-gittop-linux-x86_64-*.tar.gz
+gittop-linux-gnu-x86_64.tar.gz
+gittop-linux-musl-x86_64.tar.gz
+gittop-linux-*-*.tar.gz
 gittop-bin-*.pkg.tar.zst
 pkg/
 src/

--- a/packaging/aur/stable-bin/PKGBUILD
+++ b/packaging/aur/stable-bin/PKGBUILD
@@ -11,11 +11,11 @@ conflicts=('gittop')
 depends=('gcc-libs')
 options=('!strip' '!debug')
 install=gittop.install
-source=("gittop-${pkgver}-linux-x86_64.tar.gz::https://github.com/AmarBego/GitTop/releases/download/v${pkgver}/gittop-${pkgver}-linux-x86_64.tar.gz")
+source=("gittop-${pkgver}-linux-gnu-x86_64.tar.gz::https://github.com/AmarBego/GitTop/releases/download/v${pkgver}/gittop-${pkgver}-linux-gnu-x86_64.tar.gz")
 sha256sums=('d994f67a049c0cb1992b114effc5c5431d5640147d6dce6a373726e921dda253')
 
 package() {
-    cd "${srcdir}/gittop-${pkgver}-linux-x86_64"
+    cd "${srcdir}/gittop-${pkgver}-linux-gnu-x86_64"
     install -Dm755 "gittop" "${pkgdir}/usr/bin/gittop"
     install -Dm644 "LICENSE.md" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
     install -Dm644 "README.txt" "${pkgdir}/usr/share/doc/${pkgname}/README.txt"

--- a/packaging/copr/gittop.spec
+++ b/packaging/copr/gittop.spec
@@ -6,7 +6,7 @@ License:        AGPL-3.0-only
 URL:            https://github.com/AmarBego/GitTop
 
 # Pre-built binary tarball from GitHub releases
-Source0:        https://github.com/AmarBego/GitTop/releases/download/v%{version}/gittop-%{version}-linux-x86_64.tar.gz
+Source0:        https://github.com/AmarBego/GitTop/releases/download/v%{version}/gittop-%{version}-linux-gnu-x86_64.tar.gz
 
 # We're packaging a pre-built binary
 %global debug_package %{nil}
@@ -17,7 +17,7 @@ GitTop is a lightweight desktop client for GitHub notifications.
 No browser engine required. Pure Rust. Pure performance.
 
 %prep
-%setup -q -n gittop-%{version}-linux-x86_64
+%setup -q -n gittop-%{version}-linux-gnu-x86_64
 
 %build
 # Binary is pre-built, nothing to do

--- a/scripts/test-pkgbuild.sh
+++ b/scripts/test-pkgbuild.sh
@@ -8,7 +8,7 @@ cargo build --release
 
 # 2. Create fake release tarball structure
 VERSION=$(grep '^version =' Cargo.toml | cut -d '"' -f 2)
-DIR_NAME="gittop-linux-x86_64"
+DIR_NAME="gittop-linux-gnu-x86_64"
 rm -rf "$DIR_NAME" "$DIR_NAME.tar.gz"
 mkdir -p "$DIR_NAME"
 
@@ -20,17 +20,17 @@ cp src/platform/resources/gittop.desktop "$DIR_NAME/"
 cp assets/images/GitTop-256x256.png "$DIR_NAME/gittop.png"
 
 # 3. Compress
-tar -czf "gittop-linux-x86_64-$VERSION.tar.gz" "$DIR_NAME"
+tar -czf "gittop-linux-gnu-x86_64-$VERSION.tar.gz" "$DIR_NAME"
 
 # 4. Update PKGBUILD checksum
 echo "Updating PKGBUILD checksum..."
-SHA=$(sha256sum "gittop-linux-x86_64-$VERSION.tar.gz" | awk '{print $1}')
+SHA=$(sha256sum "gittop-linux-gnu-x86_64-$VERSION.tar.gz" | awk '{print $1}')
 sed -i "s/sha256sums=('.*')/sha256sums=('$SHA')/" packaging/aur/PKGBUILD
 sed -i "s/pkgver=.*/pkgver=$VERSION/" packaging/aur/PKGBUILD
 
 # 5. Copy tarball to where makepkg expects it (or just run makepkg pointing to file)
 # Best way for local test: put tarball in same dir as PKGBUILD, and change source to file:// or just name
-mv "gittop-linux-x86_64-$VERSION.tar.gz" packaging/aur/
+mv "gittop-linux-gnu-x86_64-$VERSION.tar.gz" packaging/aur/
 
 echo "Ready to test!"
 echo "Run: cd packaging/aur && makepkg -fp"

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -327,9 +327,7 @@ WantedBy=default.target
         }
 
         // Fallback to XDG autostart
-        xdg_autostart_path()
-            .map(|p| p.exists())
-            .unwrap_or(false)
+        xdg_autostart_path().map(|p| p.exists()).unwrap_or(false)
     }
 
     pub fn enable() -> Result<(), OnBootError> {
@@ -409,16 +407,12 @@ X-GNOME-Autostart-enabled=true
         }
 
         // Always try to remove XDG autostart file
-        if let Some(desktop_path) = xdg_autostart_path().filter(|p| p.exists()) {
-            if let Err(e) = fs::remove_file(&desktop_path) {
-                error = Some(OnBootError::Io(e));
-            }
+        if let Some(desktop_path) = xdg_autostart_path().filter(|p| p.exists())
+            && let Err(e) = fs::remove_file(&desktop_path)
+        {
+            error = Some(OnBootError::Io(e));
         }
 
-        if let Some(e) = error {
-            Err(e)
-        } else {
-            Ok(())
-        }
+        if let Some(e) = error { Err(e) } else { Ok(()) }
     }
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -201,14 +201,21 @@ pub mod tray {
     }
 }
 
-/// Release memory back to the OS (glibc only).
+/// Release memory back to the OS.
 pub fn trim_memory() {
     #[cfg(target_env = "gnu")]
     {
+        // glibc's malloc_trim can release free memory back to the system.
         unsafe extern "C" {
             safe fn malloc_trim(pad: usize) -> i32;
         }
         malloc_trim(0);
+    }
+
+    #[cfg(target_env = "musl")]
+    {
+        // musl's allocator (mallocng) is more aggressive at returning memory to the OS,
+        // and doesn't provide a direct equivalent to malloc_trim.
     }
 }
 
@@ -280,92 +287,138 @@ WantedBy=default.target
         systemd_user_dir().map(|p| p.join("gittop.service"))
     }
 
+    fn xdg_autostart_dir() -> Option<PathBuf> {
+        dirs::config_dir().map(|p| p.join("autostart"))
+    }
+
+    fn xdg_autostart_path() -> Option<PathBuf> {
+        xdg_autostart_dir().map(|p| p.join("gittop.desktop"))
+    }
+
     fn has_systemd() -> bool {
-        Command::new("systemctl")
-            .arg("--user")
-            .arg("--version")
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+        #[cfg(target_env = "musl")]
+        {
+            // Musl-based systems like Void Linux typically don't use systemd.
+            false
+        }
+        #[cfg(not(target_env = "musl"))]
+        {
+            Command::new("systemctl")
+                .arg("--user")
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        }
     }
 
     pub fn is_enabled() -> bool {
-        if !has_systemd() {
-            return false;
+        // Check systemd first
+        if has_systemd() {
+            let systemd_enabled = Command::new("systemctl")
+                .args(["--user", "is-enabled", "gittop.service"])
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false);
+
+            if systemd_enabled {
+                return true;
+            }
         }
 
-        Command::new("systemctl")
-            .args(["--user", "is-enabled", "gittop.service"])
-            .output()
-            .map(|o| o.status.success())
+        // Fallback to XDG autostart
+        xdg_autostart_path()
+            .map(|p| p.exists())
             .unwrap_or(false)
     }
 
     pub fn enable() -> Result<(), OnBootError> {
-        if !has_systemd() {
-            return Err(OnBootError::NotSupported);
-        }
-
         let exec_path = std::env::current_exe()
             .map_err(OnBootError::Io)?
             .to_string_lossy()
             .to_string();
 
-        let service_content = SYSTEMD_SERVICE_TEMPLATE.replace("{EXEC_PATH}", &exec_path);
+        if has_systemd() {
+            let service_content = SYSTEMD_SERVICE_TEMPLATE.replace("{EXEC_PATH}", &exec_path);
+            let service_dir = systemd_user_dir().ok_or(OnBootError::NotSupported)?;
+            fs::create_dir_all(&service_dir)?;
+            let service_path = systemd_service_path().ok_or(OnBootError::NotSupported)?;
+            fs::write(&service_path, service_content)?;
 
-        let service_dir = systemd_user_dir().ok_or(OnBootError::NotSupported)?;
-        fs::create_dir_all(&service_dir)?;
+            let reload = Command::new("systemctl")
+                .args(["--user", "daemon-reload"])
+                .output()?;
 
-        let service_path = systemd_service_path().ok_or(OnBootError::NotSupported)?;
-        fs::write(&service_path, service_content)?;
+            if reload.status.success() {
+                let enable = Command::new("systemctl")
+                    .args(["--user", "enable", "gittop.service"])
+                    .output()?;
 
-        let reload = Command::new("systemctl")
-            .args(["--user", "daemon-reload"])
-            .output()?;
-
-        if !reload.status.success() {
-            return Err(OnBootError::CommandFailed(
-                String::from_utf8_lossy(&reload.stderr).to_string(),
-            ));
+                if enable.status.success() {
+                    return Ok(());
+                }
+            }
+            // If systemd fails for some reason (e.g. broken user session), fall through to XDG
         }
 
-        let enable = Command::new("systemctl")
-            .args(["--user", "enable", "gittop.service"])
-            .output()?;
+        // XDG Autostart Fallback (Universal)
+        let autostart_dir = xdg_autostart_dir().ok_or(OnBootError::NotSupported)?;
+        fs::create_dir_all(&autostart_dir)?;
 
-        if !enable.status.success() {
-            return Err(OnBootError::CommandFailed(
-                String::from_utf8_lossy(&enable.stderr).to_string(),
-            ));
-        }
+        let desktop_content = format!(
+            r#"[Desktop Entry]
+Name=GitTop
+Comment=GitHub Notifications Manager
+Exec={}
+Icon=gittop
+Terminal=false
+Type=Application
+Categories=Development;Utility;
+X-GNOME-Autostart-enabled=true
+"#,
+            exec_path
+        );
+
+        let desktop_path = xdg_autostart_path().ok_or(OnBootError::NotSupported)?;
+        fs::write(&desktop_path, desktop_content)?;
 
         Ok(())
     }
 
     pub fn disable() -> Result<(), OnBootError> {
-        if !has_systemd() {
-            return Err(OnBootError::NotSupported);
+        let mut error = None;
+
+        // Try disabling systemd
+        if has_systemd() {
+            let disable = Command::new("systemctl")
+                .args(["--user", "--quiet", "disable", "gittop.service"])
+                .output()?;
+
+            if disable.status.success() {
+                if let Some(service_path) = systemd_service_path().filter(|p| p.exists()) {
+                    let _ = fs::remove_file(&service_path);
+                }
+                let _ = Command::new("systemctl")
+                    .args(["--user", "daemon-reload"])
+                    .output();
+            } else {
+                error = Some(OnBootError::CommandFailed(
+                    String::from_utf8_lossy(&disable.stderr).to_string(),
+                ));
+            }
         }
 
-        let disable = Command::new("systemctl")
-            .args(["--user", "--quiet", "disable", "gittop.service"])
-            .output()?;
-
-        // With --quiet, systemctl returns success even if unit doesn't exist
-        if !disable.status.success() {
-            return Err(OnBootError::CommandFailed(
-                String::from_utf8_lossy(&disable.stderr).to_string(),
-            ));
+        // Always try to remove XDG autostart file
+        if let Some(desktop_path) = xdg_autostart_path().filter(|p| p.exists()) {
+            if let Err(e) = fs::remove_file(&desktop_path) {
+                error = Some(OnBootError::Io(e));
+            }
         }
 
-        if let Some(service_path) = systemd_service_path().filter(|p| p.exists()) {
-            fs::remove_file(&service_path)?;
+        if let Some(e) = error {
+            Err(e)
+        } else {
+            Ok(())
         }
-
-        let _ = Command::new("systemctl")
-            .args(["--user", "daemon-reload"])
-            .output();
-
-        Ok(())
     }
 }

--- a/www/content/dev/PIPELINES.md
+++ b/www/content/dev/PIPELINES.md
@@ -28,7 +28,8 @@ This is the core workflow. It listens for any tag starting with `v*` (like `v0.1
 *   **Packages** the installers:
     *   `gittop-X.Y.Z-setup.exe` (Inno Setup)
     *   `gittop-windows-x86_64.zip` (Portable)
-    *   `gittop-linux-x86_64.tar.gz`
+    *   `gittop-linux-gnu-x86_64.tar.gz`
+    *   `gittop-linux-musl-x86_64.tar.gz`
 *   **Creates the GitHub Release**: Uploads all artifacts and checksums.
 *   **Exports Metadata**: Saves a `release-meta` artifact containing the version tag and whether it's a pre-release.
 

--- a/www/content/dev/PIPELINES.md
+++ b/www/content/dev/PIPELINES.md
@@ -28,8 +28,11 @@ This is the core workflow. It listens for any tag starting with `v*` (like `v0.1
 *   **Packages** the installers:
     *   `gittop-X.Y.Z-setup.exe` (Inno Setup)
     *   `gittop-windows-x86_64.zip` (Portable)
+    *   `gittop-windows-aarch64.zip` (Portable)
     *   `gittop-linux-gnu-x86_64.tar.gz`
     *   `gittop-linux-musl-x86_64.tar.gz`
+    *   `gittop-linux-gnu-aarch64.tar.gz`
+    *   `gittop-linux-musl-aarch64.tar.gz`
 *   **Creates the GitHub Release**: Uploads all artifacts and checksums.
 *   **Exports Metadata**: Saves a `release-meta` artifact containing the version tag and whether it's a pre-release.
 

--- a/www/content/dev/RELEASING.md
+++ b/www/content/dev/RELEASING.md
@@ -78,9 +78,12 @@ Once the tag is pushed, the `release.yml` workflow kicks in:
 1.  **Builds** binaries and installers for Windows and Linux.
 2.  **Creates a GitHub Release** with the artifacts:
     - `gittop-windows-x86_64.zip`
+    - `gittop-windows-aarch64.zip`
     - `gittop-X.Y.Z-setup.exe`
     - `gittop-linux-gnu-x86_64.tar.gz`
     - `gittop-linux-musl-x86_64.tar.gz`
+    - `gittop-linux-gnu-aarch64.tar.gz`
+    - `gittop-linux-musl-aarch64.tar.gz`
     - `SHA256SUMS.txt`
 3.  **Updates Package Managers** (Stable releases only):
     - **Scoop**: Updates the manifest in our bucket.

--- a/www/content/dev/RELEASING.md
+++ b/www/content/dev/RELEASING.md
@@ -79,7 +79,8 @@ Once the tag is pushed, the `release.yml` workflow kicks in:
 2.  **Creates a GitHub Release** with the artifacts:
     - `gittop-windows-x86_64.zip`
     - `gittop-X.Y.Z-setup.exe`
-    - `gittop-linux-x86_64.tar.gz`
+    - `gittop-linux-gnu-x86_64.tar.gz`
+    - `gittop-linux-musl-x86_64.tar.gz`
     - `SHA256SUMS.txt`
 3.  **Updates Package Managers** (Stable releases only):
     - **Scoop**: Updates the manifest in our bucket.


### PR DESCRIPTION
## What changed?
1. added musl support and switched binaries for linux to -gnu -musl
2. added .desktop fallback for non systemd support for autostart

## Why?
going to ship this to VUP (void linux) and overall bigger reach to ecosystems

## How was this tested?
fully on my void linux station

## Platforms tested
- [ ] Windows
- [X] Linux
- [ ] FreeBSD

## Fixes (if applicable)
Fixes #