### PR TITLE
Fix/GitHub returning null

### DIFF
--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -1,7 +1,7 @@
 //! GitHub API client using Personal Access Tokens.
 
-use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue, USER_AGENT};
-use serde::Deserialize;
+use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue, USER_AGENT};
+use serde::{Deserialize, de::DeserializeOwned};
 use thiserror::Error;
 
 use super::types::{Notification, NotificationView, UserInfo};
@@ -29,6 +29,16 @@ impl From<reqwest::Error> for GitHubError {
     fn from(e: reqwest::Error) -> Self {
         GitHubError::Request(e.to_string())
     }
+}
+
+fn body_snippet(body: &str) -> String {
+    const MAX_CHARS: usize = 500;
+
+    let mut snippet: String = body.chars().take(MAX_CHARS).collect();
+    if body.chars().count() > MAX_CHARS {
+        snippet.push_str("...");
+    }
+    snippet
 }
 
 /// Raw GitHub user response.
@@ -147,6 +157,37 @@ impl GitHubClient {
         }
     }
 
+    async fn decode_json<T>(response: reqwest::Response, endpoint: &str) -> Result<T, GitHubError>
+    where
+        T: DeserializeOwned,
+    {
+        let status = response.status();
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("<missing>")
+            .to_string();
+
+        let body = response.text().await.map_err(|e| {
+            GitHubError::Request(format!(
+                "Failed to read response body from {} (status {}, content-type {}): {}",
+                endpoint, status, content_type, e
+            ))
+        })?;
+
+        serde_json::from_str(&body).map_err(|e| {
+            GitHubError::Request(format!(
+                "Failed to decode JSON response from {} (status {}, content-type {}): {}; body: {}",
+                endpoint,
+                status,
+                content_type,
+                e,
+                body_snippet(&body)
+            ))
+        })
+    }
+
     /// Fetches the authenticated user's information.
     /// This is used to validate the token and get user details.
     pub async fn get_authenticated_user(&self) -> Result<UserInfo, GitHubError> {
@@ -155,7 +196,7 @@ impl GitHubClient {
         let response = self.client.get(&url).send().await?;
         let response = Self::handle_response(response).await?;
 
-        let user: GitHubUser = response.json().await?;
+        let user: GitHubUser = Self::decode_json(response, &url).await?;
         Ok(UserInfo {
             login: user.login,
             name: user.name,
@@ -210,7 +251,7 @@ impl GitHubClient {
 
         let response = self.client.get(&url).send().await?;
         let response = Self::handle_response(response).await?;
-        Ok(response.json().await?)
+        Self::decode_json(response, &url).await
     }
 
     /// Fetches notifications and converts them to frontend-friendly format.

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -165,7 +165,7 @@ pub struct Repository {
     pub id: u64,
     pub name: String,
     pub full_name: String,
-    pub owner: Owner,
+    pub owner: Option<Owner>,
     pub html_url: String,
     pub private: bool,
 }
@@ -203,6 +203,13 @@ pub struct NotificationView {
 impl NotificationView {
     /// Create a NotificationView from a Notification with the account name.
     pub fn from_notification(n: Notification, account: impl Into<String>) -> Self {
+        let avatar_url = n
+            .repository
+            .owner
+            .as_ref()
+            .map(|owner| owner.avatar_url.clone())
+            .unwrap_or_default();
+
         Self {
             id: n.id,
             title: n.subject.title,
@@ -214,7 +221,7 @@ impl NotificationView {
             updated_at: n.updated_at,
             url: n.subject.url,
             latest_comment_url: n.subject.latest_comment_url,
-            avatar_url: n.repository.owner.avatar_url,
+            avatar_url,
             is_private: n.repository.private,
             account: account.into(),
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -160,6 +160,8 @@ pub struct AppSettings {
     pub power_mode: bool,
     #[serde(default = "default_show_details_panel")]
     pub show_details_panel: bool,
+    #[serde(default = "default_show_notification_avatars")]
+    pub show_notification_avatars: bool,
     #[serde(default)]
     pub proxy: ProxySettings,
     /// Check for updates on startup (opt-in, default: false)
@@ -198,6 +200,10 @@ fn default_show_details_panel() -> bool {
     true
 }
 
+fn default_show_notification_avatars() -> bool {
+    true
+}
+
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
@@ -214,6 +220,7 @@ impl Default for AppSettings {
             window_height: 640.0,
             power_mode: false,
             show_details_panel: true,
+            show_notification_avatars: true,
             proxy: ProxySettings::default(),
             check_for_updates: false,
             credential_storage: CredentialStorage::default(),

--- a/src/ui/features/general_settings/message.rs
+++ b/src/ui/features/general_settings/message.rs
@@ -4,6 +4,7 @@ pub enum GeneralMessage {
     ToggleIconTheme(bool),
     ToggleMinimizeToTray(bool),
     ToggleCheckForUpdates(bool),
+    ToggleNotificationAvatars(bool),
     SetNotificationFontScale(f32),
     SetSidebarFontScale(f32),
     SetSidebarWidth(f32),

--- a/src/ui/features/general_settings/update.rs
+++ b/src/ui/features/general_settings/update.rs
@@ -62,6 +62,12 @@ pub fn update(
             tracing::info!(enabled, "Check for updates setting updated");
             Task::none()
         }
+        GeneralMessage::ToggleNotificationAvatars(enabled) => {
+            settings.show_notification_avatars = enabled;
+            persist_settings(settings);
+            tracing::info!(enabled, "Notification avatars setting updated");
+            Task::none()
+        }
         GeneralMessage::ToggleStartOnBoot(enabled) => {
             tracing::info!(enabled, "Start-on-boot toggle requested");
             // Perform the operation asynchronously and report result

--- a/src/ui/features/general_settings/view.rs
+++ b/src/ui/features/general_settings/view.rs
@@ -29,6 +29,8 @@ pub fn view(
         view_start_on_boot(state.start_on_boot_enabled),
         Space::new().height(8),
         view_check_for_updates(settings),
+        Space::new().height(8),
+        view_notification_avatars(settings),
         Space::new().height(24),
         text("Display").size(13).color(p.text_muted),
         Space::new().height(8),
@@ -130,6 +132,22 @@ fn view_check_for_updates(settings: &AppSettings) -> Element<'static, GeneralMes
         desc,
         enabled,
         GeneralMessage::ToggleCheckForUpdates,
+    )
+}
+
+fn view_notification_avatars(settings: &AppSettings) -> Element<'static, GeneralMessage> {
+    let enabled = settings.show_notification_avatars;
+    let desc = if enabled {
+        "Loads the selected notification's repo avatar in details (Default)"
+    } else {
+        "Uses initials only and keeps avatar image bytes out of memory"
+    };
+
+    toggle_card(
+        "Notification Avatars",
+        desc,
+        enabled,
+        GeneralMessage::ToggleNotificationAvatars,
     )
 }
 

--- a/src/ui/features/general_settings/view.rs
+++ b/src/ui/features/general_settings/view.rs
@@ -20,25 +20,38 @@ pub fn view(
             .size(12)
             .color(p.text_secondary),
         Space::new().height(16),
-        view_theme(settings),
-        Space::new().height(8),
-        view_icons(settings),
-        Space::new().height(8),
-        view_minimize_to_tray(settings),
-        Space::new().height(8),
-        view_start_on_boot(state.start_on_boot_enabled),
-        Space::new().height(8),
-        view_check_for_updates(settings),
-        Space::new().height(8),
-        view_notification_avatars(settings),
-        Space::new().height(24),
-        text("Display").size(13).color(p.text_muted),
-        Space::new().height(8),
-        view_notification_scale(settings),
-        Space::new().height(8),
-        view_sidebar_scale(settings),
-        Space::new().height(8),
-        view_sidebar_width(settings),
+        settings_group(
+            "Appearance",
+            column![
+                view_theme(settings),
+                Space::new().height(8),
+                view_icons(settings),
+                Space::new().height(8),
+                view_notification_avatars(settings),
+            ],
+        ),
+        Space::new().height(16),
+        settings_group(
+            "App Behavior",
+            column![
+                view_minimize_to_tray(settings),
+                Space::new().height(8),
+                view_start_on_boot(state.start_on_boot_enabled),
+            ],
+        ),
+        Space::new().height(16),
+        settings_group("GitHub", column![view_check_for_updates(settings),],),
+        Space::new().height(16),
+        settings_group(
+            "Display",
+            column![
+                view_notification_scale(settings),
+                Space::new().height(8),
+                view_sidebar_scale(settings),
+                Space::new().height(8),
+                view_sidebar_width(settings),
+            ],
+        ),
     ]
     .spacing(4)
     .padding(24)
@@ -190,6 +203,21 @@ fn view_sidebar_width(settings: &AppSettings) -> Element<'static, GeneralMessage
 // ============================================================================
 // Helpers
 // ============================================================================
+
+fn settings_group<'a>(
+    title: &'static str,
+    content: iced::widget::Column<'a, GeneralMessage>,
+) -> Element<'a, GeneralMessage> {
+    let p = theme::palette();
+
+    column![
+        text(title).size(13).color(p.text_muted),
+        Space::new().height(8),
+        content,
+    ]
+    .width(Fill)
+    .into()
+}
 
 fn toggle_card<'a>(
     title: &'static str,

--- a/src/ui/features/notification_details/message.rs
+++ b/src/ui/features/notification_details/message.rs
@@ -19,4 +19,5 @@ pub enum NotificationDetailsMessage {
     ChecksLoaded(Result<CheckRunsResponse, GitHubError>),
     LoadComments(String),
     CommentsLoaded(Result<Vec<CommentDetails>, GitHubError>),
+    AvatarLoaded(String, Result<Vec<u8>, String>),
 }

--- a/src/ui/features/notification_details/state.rs
+++ b/src/ui/features/notification_details/state.rs
@@ -34,4 +34,22 @@ impl NotificationDetailsState {
     pub fn new() -> Self {
         Self::default()
     }
+
+    pub fn enter_low_memory_mode(&mut self) {
+        self.selected_id = None;
+        self.details = None;
+        self.detail_error = None;
+        self.is_loading = false;
+        self.label_input.clear();
+        self.available_labels = Vec::new();
+        self.labels_loading = false;
+        self.pending_label_ops.clear();
+        self.label_error = None;
+        self.check_runs = Vec::new();
+        self.checks_loading = false;
+        self.comments = None;
+        self.comments_loading = false;
+        self.comments_error = None;
+        self.avatar_handle = None;
+    }
 }

--- a/src/ui/features/notification_details/state.rs
+++ b/src/ui/features/notification_details/state.rs
@@ -8,12 +8,14 @@
 
 use crate::github::NotificationSubjectDetail;
 use crate::github::subject_details::{CheckRun, CommentDetails, Label};
+use iced::widget::image;
 use std::collections::HashSet;
 
 #[derive(Debug, Clone, Default)]
 pub struct NotificationDetailsState {
     pub selected_id: Option<String>,
     pub details: Option<NotificationSubjectDetail>,
+    pub detail_error: Option<String>,
     pub is_loading: bool,
     pub label_input: String,
     pub available_labels: Vec<Label>,
@@ -25,6 +27,7 @@ pub struct NotificationDetailsState {
     pub comments: Option<Vec<CommentDetails>>,
     pub comments_loading: bool,
     pub comments_error: Option<String>,
+    pub avatar_handle: Option<image::Handle>,
 }
 
 impl NotificationDetailsState {

--- a/src/ui/features/notification_details/update.rs
+++ b/src/ui/features/notification_details/update.rs
@@ -14,12 +14,19 @@ pub fn update_notification_details(
     message: NotificationDetailsMessage,
     notifications: &[NotificationView],
     client: &GitHubClient,
+    avatar_enabled: bool,
 ) -> Task<NotificationDetailsMessage> {
+    if !avatar_enabled {
+        state.avatar_handle = None;
+    }
+
     match message {
         NotificationDetailsMessage::Select(id) => {
             state.selected_id = Some(id.clone());
             state.details = None;
+            state.detail_error = None;
             state.is_loading = true;
+            state.avatar_handle = None;
             state.label_input.clear();
             state.label_error = None;
             state.available_labels.clear();
@@ -52,8 +59,13 @@ pub fn update_notification_details(
                 .find(|n| n.id == id)
                 .map(|n| n.title.clone())
                 .unwrap_or_default();
+            let avatar_url = notifications
+                .iter()
+                .find(|n| n.id == id)
+                .map(|n| n.avatar_url.clone())
+                .unwrap_or_default();
 
-            Task::perform(
+            let details_task = Task::perform(
                 async move {
                     client
                         .get_notification_details(
@@ -66,7 +78,22 @@ pub fn update_notification_details(
                         .await
                 },
                 move |result| NotificationDetailsMessage::SelectComplete(id.clone(), result),
-            )
+            );
+
+            if !avatar_enabled || avatar_url.is_empty() {
+                details_task
+            } else {
+                let avatar_id = state.selected_id.clone().unwrap_or_default();
+                Task::batch(vec![
+                    details_task,
+                    Task::perform(
+                        async move { fetch_avatar_bytes(&avatar_url).await },
+                        move |result| {
+                            NotificationDetailsMessage::AvatarLoaded(avatar_id.clone(), result)
+                        },
+                    ),
+                ])
+            }
         }
 
         NotificationDetailsMessage::SelectComplete(id, result) => {
@@ -75,6 +102,7 @@ pub fn update_notification_details(
                 match result {
                     Ok(details) => {
                         let is_pr = matches!(&details, NotificationSubjectDetail::PullRequest(_));
+                        state.detail_error = None;
                         state.details = Some(details.clone());
 
                         if is_pr && let Some(notif) = notifications.iter().find(|n| n.id == id) {
@@ -118,7 +146,8 @@ pub fn update_notification_details(
                         }
                     }
                     Err(e) => {
-                        tracing::error!(error = %e, "Failed to fetch notification details");
+                        tracing::warn!(error = %e, "Notification details unavailable");
+                        state.detail_error = Some(e.to_string());
                         state.details = None;
                     }
                 }
@@ -328,7 +357,59 @@ pub fn update_notification_details(
             }
             Task::none()
         }
+
+        NotificationDetailsMessage::AvatarLoaded(id, result) => {
+            if state.selected_id.as_ref() == Some(&id) {
+                match result {
+                    Ok(bytes) => {
+                        state.avatar_handle = Some(iced::widget::image::Handle::from_bytes(bytes))
+                    }
+                    Err(e) => {
+                        tracing::debug!(error = %e, "Failed to load notification avatar");
+                        state.avatar_handle = None;
+                    }
+                }
+            }
+            Task::none()
+        }
     }
+}
+
+async fn fetch_avatar_bytes(url: &str) -> Result<Vec<u8>, String> {
+    const MAX_AVATAR_BYTES: usize = 128 * 1024;
+
+    let url = avatar_url_with_size(url)?;
+    let response = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .map_err(|e| e.to_string())?
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if !response.status().is_success() {
+        return Err(format!("avatar request failed with {}", response.status()));
+    }
+
+    if let Some(length) = response.content_length()
+        && length as usize > MAX_AVATAR_BYTES
+    {
+        return Err(format!("avatar too large: {} bytes", length));
+    }
+
+    let bytes = response.bytes().await.map_err(|e| e.to_string())?;
+    if bytes.len() > MAX_AVATAR_BYTES {
+        return Err(format!("avatar too large: {} bytes", bytes.len()));
+    }
+
+    Ok(bytes.to_vec())
+}
+
+fn avatar_url_with_size(url: &str) -> Result<reqwest::Url, String> {
+    let mut url = reqwest::Url::parse(url).map_err(|e| e.to_string())?;
+    url.query_pairs_mut().append_pair("s", "80");
+    Ok(url)
 }
 
 fn split_repo_full_name(full_name: &str) -> (&str, &str) {

--- a/src/ui/features/notification_details/view.rs
+++ b/src/ui/features/notification_details/view.rs
@@ -1,5 +1,5 @@
-use iced::widget::{Space, button, column, container, row, scrollable, text, text_input};
-use iced::{Alignment, Color, Element, Fill, Length};
+use iced::widget::{Space, button, column, container, image, row, scrollable, text, text_input};
+use iced::{Alignment, Color, ContentFit, Element, Fill, Length};
 
 use crate::github::NotificationView;
 use crate::github::subject_details::{
@@ -31,6 +31,8 @@ pub fn view<'a>(
     notification: Option<&'a NotificationView>,
     details: Option<&'a NotificationSubjectDetail>,
     is_loading: bool,
+    detail_error: Option<&'a str>,
+    avatar_handle: Option<&'a image::Handle>,
     icon_theme: IconTheme,
     label_args: LabelViewArgs<'a>,
 ) -> Element<'a, NotificationMessage> {
@@ -39,10 +41,12 @@ pub fn view<'a>(
     let content: Element<'a, NotificationMessage> = if is_loading {
         view_loading(&p)
     } else if let Some(notif) = notification {
-        if let Some(detail) = details {
-            view_details(notif, detail, icon_theme, &p, label_args)
+        if let Some(error) = detail_error {
+            view_detail_error(notif, error, avatar_handle, icon_theme, &p)
+        } else if let Some(detail) = details {
+            view_details(notif, detail, avatar_handle, icon_theme, &p, label_args)
         } else {
-            view_notification_header(notif, &p, icon_theme)
+            view_notification_header(notif, avatar_handle, &p, icon_theme)
         }
     } else {
         view_empty_state(&p)
@@ -91,15 +95,68 @@ fn view_empty_state<'a>(p: &theme::ThemePalette) -> Element<'a, NotificationMess
     .into()
 }
 
+fn view_detail_error<'a>(
+    notif: &'a NotificationView,
+    error: &'a str,
+    avatar_handle: Option<&'a image::Handle>,
+    icon_theme: IconTheme,
+    p: &theme::ThemePalette,
+) -> Element<'a, NotificationMessage> {
+    let bg_control = p.bg_control;
+    let border_subtle = p.border_subtle;
+    let accent_warning = p.accent_warning;
+    let text_primary = p.text_primary;
+    let text_secondary = p.text_secondary;
+    let text_muted = p.text_muted;
+
+    column![
+        view_repo_context(notif, avatar_handle, p, true),
+        Space::new().height(16),
+        row![
+            icons::icon_info(14.0, accent_warning, icon_theme),
+            Space::new().width(8),
+            text("Details unavailable").size(14).color(text_primary),
+        ]
+        .align_y(Alignment::Center),
+        Space::new().height(8),
+        text("This notification item could not be loaded. It may have been deleted, moved, or the repository may no longer exist.")
+            .size(12)
+            .color(text_secondary)
+            .wrapping(iced::widget::text::Wrapping::WordOrGlyph),
+        Space::new().height(12),
+        container(
+            text(error)
+                .size(11)
+                .color(text_muted)
+                .wrapping(iced::widget::text::Wrapping::WordOrGlyph),
+        )
+        .padding(10)
+        .width(Fill)
+        .style(move |_| container::Style {
+            background: Some(iced::Background::Color(bg_control)),
+            border: iced::Border {
+                radius: 6.0.into(),
+                color: border_subtle,
+                width: 1.0,
+            },
+            ..Default::default()
+        }),
+        Space::new().height(16),
+        view_action_buttons(&notif.id, notif.unread, icon_theme),
+    ]
+    .padding(24)
+    .width(Fill)
+    .into()
+}
+
 fn view_notification_header<'a>(
     notif: &'a NotificationView,
+    avatar_handle: Option<&'a image::Handle>,
     p: &theme::ThemePalette,
     icon_theme: IconTheme,
 ) -> Element<'a, NotificationMessage> {
     column![
-        text(&notif.repo_full_name).size(12).color(p.text_secondary),
-        Space::new().height(4),
-        text(&notif.title).size(18).color(p.text_primary),
+        view_repo_context(notif, avatar_handle, p, true),
         Space::new().height(16),
         text(format!("Reason: {}", notif.reason.label()))
             .size(12)
@@ -115,29 +172,35 @@ fn view_notification_header<'a>(
 fn view_details<'a>(
     notif: &'a NotificationView,
     detail: &'a NotificationSubjectDetail,
+    avatar_handle: Option<&'a image::Handle>,
     icon_theme: IconTheme,
     p: &theme::ThemePalette,
     label_args: LabelViewArgs<'a>,
 ) -> Element<'a, NotificationMessage> {
     let content: Element<'a, NotificationMessage> = match detail {
         NotificationSubjectDetail::Issue(issue) => {
-            view_issue(issue, notif, icon_theme, p, label_args)
+            view_issue(issue, notif, avatar_handle, icon_theme, p, label_args)
         }
         NotificationSubjectDetail::PullRequest(pr) => {
-            view_pull_request(pr, notif, icon_theme, p, label_args)
+            view_pull_request(pr, notif, avatar_handle, icon_theme, p, label_args)
         }
         NotificationSubjectDetail::Comment {
             comment,
             context_title,
-        } => view_comment(comment, context_title, notif, icon_theme, p),
+        } => view_comment(comment, context_title, notif, avatar_handle, icon_theme, p),
         NotificationSubjectDetail::Discussion(discussion) => {
-            view_discussion(discussion, notif, icon_theme, p)
+            view_discussion(discussion, notif, avatar_handle, icon_theme, p)
         }
-        NotificationSubjectDetail::SecurityAlert { title, severity } => {
-            view_security_alert(title, severity.as_deref(), notif, icon_theme, p)
-        }
+        NotificationSubjectDetail::SecurityAlert { title, severity } => view_security_alert(
+            title,
+            severity.as_deref(),
+            notif,
+            avatar_handle,
+            icon_theme,
+            p,
+        ),
         NotificationSubjectDetail::Unsupported { subject_type } => {
-            view_unsupported(subject_type, notif, icon_theme, p)
+            view_unsupported(subject_type, notif, avatar_handle, icon_theme, p)
         }
     };
 
@@ -151,6 +214,7 @@ fn view_details<'a>(
 fn view_issue<'a>(
     issue: &'a IssueDetails,
     notif: &'a NotificationView,
+    avatar_handle: Option<&'a image::Handle>,
     icon_theme: IconTheme,
     p: &theme::ThemePalette,
     label_args: LabelViewArgs<'a>,
@@ -168,6 +232,8 @@ fn view_issue<'a>(
     let text_muted = p.text_muted;
 
     let mut col = column![
+        view_repo_context(notif, avatar_handle, p, false),
+        Space::new().height(16),
         row![
             icons::icon_issue(14.0, state_color, icon_theme),
             Space::new().width(8),
@@ -246,6 +312,7 @@ fn view_issue<'a>(
 fn view_pull_request<'a>(
     pr: &'a PullRequestDetails,
     notif: &'a NotificationView,
+    avatar_handle: Option<&'a image::Handle>,
     icon_theme: IconTheme,
     p: &theme::ThemePalette,
     label_args: LabelViewArgs<'a>,
@@ -276,6 +343,8 @@ fn view_pull_request<'a>(
     let pr_number = pr.number;
 
     let mut col = column![
+        view_repo_context(notif, avatar_handle, p, false),
+        Space::new().height(16),
         row![
             icons::icon_pull_request(14.0, state_color, icon_theme),
             Space::new().width(8),
@@ -633,6 +702,7 @@ fn view_comment<'a>(
     comment: &'a CommentDetails,
     context_title: &'a str,
     notif: &'a NotificationView,
+    avatar_handle: Option<&'a image::Handle>,
     icon_theme: IconTheme,
     p: &theme::ThemePalette,
 ) -> Element<'a, NotificationMessage> {
@@ -643,6 +713,8 @@ fn view_comment<'a>(
     let accent = p.accent;
 
     column![
+        view_repo_context(notif, avatar_handle, p, false),
+        Space::new().height(16),
         row![
             icons::icon_at(14.0, accent, icon_theme),
             Space::new().width(8),
@@ -677,6 +749,7 @@ fn view_comment<'a>(
 fn view_discussion<'a>(
     discussion: &'a DiscussionDetails,
     notif: &'a NotificationView,
+    avatar_handle: Option<&'a image::Handle>,
     icon_theme: IconTheme,
     p: &theme::ThemePalette,
 ) -> Element<'a, NotificationMessage> {
@@ -700,8 +773,8 @@ fn view_discussion<'a>(
         .unwrap_or_else(|| "Discussion".to_string());
 
     let mut col = column![
-        text(&notif.repo_full_name).size(11).color(text_muted),
-        Space::new().height(6),
+        view_repo_context(notif, avatar_handle, p, false),
+        Space::new().height(16)
     ]
     .width(Fill);
 
@@ -791,6 +864,7 @@ fn view_security_alert<'a>(
     title: &'a str,
     severity: Option<&'a str>,
     notif: &'a NotificationView,
+    avatar_handle: Option<&'a image::Handle>,
     icon_theme: IconTheme,
     p: &theme::ThemePalette,
 ) -> Element<'a, NotificationMessage> {
@@ -804,6 +878,8 @@ fn view_security_alert<'a>(
     let accent_danger = p.accent_danger;
 
     column![
+        view_repo_context(notif, avatar_handle, p, false),
+        Space::new().height(16),
         row![
             icons::icon_security(14.0, accent_danger, icon_theme),
             Space::new().width(8),
@@ -838,13 +914,12 @@ fn view_security_alert<'a>(
 fn view_unsupported<'a>(
     subject_type: &'a str,
     notif: &'a NotificationView,
+    avatar_handle: Option<&'a image::Handle>,
     icon_theme: IconTheme,
     p: &theme::ThemePalette,
 ) -> Element<'a, NotificationMessage> {
     column![
-        text(&notif.repo_full_name).size(12).color(p.text_secondary),
-        Space::new().height(4),
-        text(&notif.title).size(16).color(p.text_primary),
+        view_repo_context(notif, avatar_handle, p, true),
         Space::new().height(16),
         text(format!("Type: {}", subject_type))
             .size(12)
@@ -859,6 +934,106 @@ fn view_unsupported<'a>(
     .padding(24)
     .width(Fill)
     .into()
+}
+
+fn view_repo_context<'a>(
+    notif: &'a NotificationView,
+    avatar_handle: Option<&'a image::Handle>,
+    p: &theme::ThemePalette,
+    show_title: bool,
+) -> Element<'a, NotificationMessage> {
+    let mut text_column =
+        column![text(&notif.repo_full_name).size(12).color(p.text_secondary)].width(Fill);
+
+    if show_title {
+        text_column = text_column.push(Space::new().height(3));
+        text_column = text_column.push(
+            text(&notif.title)
+                .size(16)
+                .color(p.text_primary)
+                .wrapping(iced::widget::text::Wrapping::WordOrGlyph),
+        );
+    }
+
+    row![
+        repo_owner_avatar(notif.repo_owner(), avatar_handle, 40.0, p),
+        Space::new().width(12),
+        text_column,
+    ]
+    .align_y(Alignment::Center)
+    .width(Fill)
+    .into()
+}
+
+fn repo_owner_avatar(
+    owner: &str,
+    avatar_handle: Option<&image::Handle>,
+    size: f32,
+    p: &theme::ThemePalette,
+) -> Element<'static, NotificationMessage> {
+    if let Some(handle) = avatar_handle {
+        return container(
+            image(handle)
+                .width(size)
+                .height(size)
+                .content_fit(ContentFit::Cover)
+                .border_radius(size / 2.0),
+        )
+        .width(size)
+        .height(size)
+        .into();
+    }
+
+    let accent = avatar_color(owner, p);
+    let initials = owner_initials(owner);
+
+    container(
+        text(initials)
+            .size((size * 0.42).max(10.0))
+            .color(accent)
+            .align_x(Alignment::Center),
+    )
+    .width(size)
+    .height(size)
+    .align_x(Alignment::Center)
+    .align_y(Alignment::Center)
+    .style(move |_| container::Style {
+        background: Some(iced::Background::Color(Color::from_rgba(
+            accent.r, accent.g, accent.b, 0.14,
+        ))),
+        border: iced::Border {
+            radius: (size / 2.0).into(),
+            color: Color::from_rgba(accent.r, accent.g, accent.b, 0.2),
+            width: 1.0,
+        },
+        ..Default::default()
+    })
+    .into()
+}
+
+fn owner_initials(owner: &str) -> String {
+    owner
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter_map(|part| part.chars().next())
+        .take(2)
+        .collect::<String>()
+        .to_ascii_uppercase()
+}
+
+fn avatar_color(owner: &str, p: &theme::ThemePalette) -> Color {
+    let colors = [
+        p.accent,
+        p.accent_success,
+        p.accent_purple,
+        p.accent_warning,
+        p.accent_danger,
+        p.text_secondary,
+    ];
+    let hash = owner.bytes().fold(0usize, |hash, byte| {
+        hash.wrapping_mul(31).wrapping_add(byte as usize)
+    });
+
+    colors[hash % colors.len()]
 }
 
 fn view_action_buttons(

--- a/src/ui/features/power_mode/view.rs
+++ b/src/ui/features/power_mode/view.rs
@@ -31,6 +31,11 @@ pub fn app_layout<'a>(
                 screen.selected_notification(),
                 screen.selected_details(),
                 screen.notification_details.is_loading,
+                screen.notification_details.detail_error.as_deref(),
+                settings
+                    .show_notification_avatars
+                    .then_some(screen.notification_details.avatar_handle.as_ref())
+                    .flatten(),
                 settings.icon_theme,
                 notification_details::view::LabelViewArgs {
                     input: &screen.notification_details.label_input,

--- a/src/ui/screens/notifications/screen.rs
+++ b/src/ui/screens/notifications/screen.rs
@@ -104,7 +104,13 @@ impl NotificationsScreen {
 
     pub fn enter_low_memory_mode(&mut self) {
         self.processing.enter_low_memory_mode();
-        self.error_message = None;
+        self.notification_details.enter_low_memory_mode();
+        self.bulk_actions.clear();
+        self.thread_actions.pending_mark_read.clear();
+        self.thread_actions.pending_mark_read.shrink_to_fit();
+        self.thread_actions.pending_mark_done.clear();
+        self.thread_actions.pending_mark_done.shrink_to_fit();
+        self.thread_actions.pending_mark_all = false;
         self.error_message = None;
         self.list_state.reset();
 

--- a/src/ui/screens/notifications/screen.rs
+++ b/src/ui/screens/notifications/screen.rs
@@ -178,6 +178,7 @@ impl NotificationsScreen {
                     msg,
                     &self.processing.all_notifications,
                     &self.client,
+                    true,
                 );
                 task.map(NotificationMessage::Details)
             }
@@ -270,6 +271,16 @@ impl NotificationsScreen {
             },
 
             // Other messages handled normally
+            NotificationMessage::Details(msg) => {
+                let task = update_notification_details(
+                    &mut self.notification_details,
+                    msg,
+                    &self.processing.all_notifications,
+                    &self.client,
+                    ctx.settings.show_notification_avatars,
+                );
+                (task.map(NotificationMessage::Details), AppEffect::None)
+            }
             other => (self.update(other), AppEffect::None),
         }
     }


### PR DESCRIPTION
## What changed?
1. GitHub can return repository.owner: null in a successful notifications response. Our model required owner to always be
present, so deserialization failed and the whole refresh errored. The fix makes owner optional and uses an empty
avatar fallback.
2. This also adds optional repository-owner avatars in the notification detail panel. Avatars are enabled by default, can be disabled in General settings, and are only loaded for the currently selected notification
3. Added graceful 404 handling for deleted or missing notification targets: the detail panel now shows a clear “Details unavailable” state with the GitHub error code instead of falling back to an empty/generic view.
4. Low-memory/tray mode now drops transient detail state, including avatar handles, loaded comments, labels, checks, selection state, and pending UI state.

## Why?
1. A single malformed or partial notification response should not prevent the entire inbox from refreshing.
2. The avatar handling needed to be defensive too: if GitHub omits owner data, avatar loading is disabled, or an avatar fetch fails, the UI falls back to initials instead of retaining image bytes or blocking the detail view.
3. more of a quality of life change, tells you the notification is broken (deleted repo, deleted issue etc.)


## How was this tested?
fully

## Platforms tested
- [x] Windows
- [x] Linux
- [ ] FreeBSD

## Fixes (if applicable)
Fixes #